### PR TITLE
feat: translate nav bar

### DIFF
--- a/components/layout/nav-bar.tsx
+++ b/components/layout/nav-bar.tsx
@@ -6,25 +6,28 @@ import LocaleSwitcher from "./locale-switcher";
 import ThemeSwitcher from "./theme-switcher";
 import { getCurrentUser } from "@/lib/auth";
 import { ArrowRight } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { use } from "react";
 
-export default async function NavBar() {
-  const userRes = await getCurrentUser();
+export default function NavBar() {
+  const t = useTranslations("navBar");
+  const userRes = use(getCurrentUser());
 
   return (
     <div className="w-full h-16 p-4 flex justify-end items-center">
       <div className="flex items-center gap-2">
         <div className="flex items-center gap-1 text-muted-foreground">
-          <p>try it out</p>
+          <p>{t("tryItOut")}</p>
           <ArrowRight className="size-3" />
         </div>
 
         {userRes.success ? (
           <Button size={"sm"} variant={"outline"} asChild>
-            <Link href="/profile">Profile</Link>
+            <Link href="/profile">{t("profile")}</Link>
           </Button>
         ) : (
           <Button size={"sm"} variant={"outline"} asChild>
-            <Link href="/auth/login">Log In</Link>
+            <Link href="/auth/login">{t("logIn")}</Link>
           </Button>
         )}
         <LocaleSwitcher />

--- a/messages/en.json
+++ b/messages/en.json
@@ -9,6 +9,11 @@
     "cta": "Try it out by creating an account, or;",
     "buttonText": "Deploy with Vercel"
   },
+  "navBar": {
+    "tryItOut": "try it out",
+    "profile": "Profile",
+    "logIn": "Log In"
+  },
   "userPage": {
     "greeting": "Hello {name} 👋",
     "message": "You are now logged in. You can find your profile data below, edit it, or log out.",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -9,6 +9,11 @@
     "cta": "Probeer het uit door een account aan te maken, of;",
     "buttonText": "Deploy met Vercel"
   },
+  "navBar": {
+    "tryItOut": "Probeer het uit",
+    "profile": "Profiel",
+    "logIn": "Inloggen"
+  },
   "userPage": {
     "greeting": "Hallo {name} 👋",
     "message": "Je bent nu ingelogd. Hieronder vind je je profielgegevens. Je kunt ze bewerken of uitloggen.",


### PR DESCRIPTION
## Summary
- add NavBar translation keys for "try it out", "Profile" and "Log In"
- localize NavBar text with `useTranslations`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: `react/no-unescaped-entities` and other existing warnings)*


------
https://chatgpt.com/codex/tasks/task_b_689cb2f6be608322971610c145d26b3c